### PR TITLE
Shuffle application logic for deployment into app model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 tmp/.netrc
 .irb.history
 .env
+.ruby-version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,7 +42,7 @@ Documentation:
     - !ruby/regexp /spec\/*\/*/
 
 ClassLength:
-  Max: 175
+  Max: 115
   Exclude:
     - !ruby/regexp /spec\/*\/*/
 

--- a/lib/escobar/heroku/app.rb
+++ b/lib/escobar/heroku/app.rb
@@ -20,9 +20,94 @@ module Escobar
         "https://dashboard.heroku.com/apps/#{name}"
       end
 
+      def locked?
+        response = client.heroku.get("/apps/#{id}/config-vars")
+        response["id"] == "two_factor"
+      end
+
       # Accepts either google authenticator or yubikey second_factor formatting
       def preauth(second_factor)
         !client.heroku.put("/apps/#{id}/pre-authorizations", second_factor).any?
+      end
+
+      def create_build(ref, environment, force, custom_payload)
+        deployment = create_github_deployment("deploy", ref, environment,
+                                              force, custom_payload)
+
+        return({ error: deployment["message"] }) unless deployment["sha"]
+
+        sha   = github_deployment["sha"]
+        build = create_heroku_build(app.name, sha)
+        create_deployment_from(app, deployment, sha, build)
+      end
+
+      # rubocop:disable Metrics/LineLength
+      def create_deployment_from(app, github_deployment, sha, build)
+        case build["id"]
+        when "two_factor"
+          description = "A second factor is required. Use your configured " \
+                        "authenticator app or yubikey."
+          create_github_deployment_status(github_deployment["url"], nil, "failure", description)
+          { error: build["message"] }
+        when Escobar::Heroku::BuildRequestSuccess
+          target_url = "https://dashboard.heroku.com/apps/#{app.name}/" \
+                       "activity/builds/#{build['id']}"
+
+          create_github_deployment_status(github_deployment["url"],
+                                          target_url,
+                                          "pending",
+                                          "Build running..")
+          {
+            sha: sha,
+            name: name,
+            repo: github_repository,
+            app_id: app.name,
+            build_id: build["id"],
+            target_url: target_url,
+            deployment_url: github_deployment["url"]
+          }
+        else
+          { error: "Unable to create heroku build for #{name}" }
+        end
+      end
+      # rubocop:enable Metrics/LineLength
+
+      def create_heroku_build(app_name, sha)
+        body = {
+          source_blob: {
+            url: github_client.archive_link(sha),
+            version: sha[0..7],
+            version_description: "#{github_repository}:#{sha}"
+          }
+        }
+        client.heroku.post("/apps/#{app_name}/builds", body)
+      end
+
+      def create_github_deployment(task, ref, environment, force, extras = {})
+        required_contexts = required_commit_contexts(force)
+
+        options = {
+          ref: ref,
+          task: task,
+          auto_merge: !force,
+          payload: extras.merge(custom_deployment_payload),
+          environment: environment,
+          required_contexts: required_contexts
+        }
+        github_client.create_deployment(options)
+      end
+
+      def create_github_deployment_status(url, target_url, state, description)
+        payload = {
+          state: state,
+          target_url: target_url,
+          description: description
+        }
+        create_deployment_status(url, payload)
+      end
+
+      def create_deployment_status(url, payload)
+        github_client.create_deployment_status(url, payload)
       end
     end
   end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.2.1".freeze
+  VERSION = "0.2.2.pre1".freeze
 end

--- a/spec/lib/escobar/heroku/app_spec.rb
+++ b/spec/lib/escobar/heroku/app_spec.rb
@@ -5,6 +5,7 @@ describe Escobar::Heroku::App do
   let(:name) { "slash-heroku" }
   let(:client) { Escobar::Client.from_environment }
   let(:pipeline) { Escobar::Heroku::Pipeline.new(client, id, name) }
+  let(:app) { pipeline.environments["production"].first.app }
 
   before do
     stub_heroku_response("/pipelines")
@@ -17,12 +18,6 @@ describe Escobar::Heroku::App do
   end
 
   it "handle preauthorization success" do
-    expect(pipeline.github_repository).to eql("atmos/slash-heroku")
-    expect(pipeline).to be_configured
-
-    production = pipeline.environments["production"]
-    app = production.first.app
-
     expect(app.name).to eql("slash-heroku-production")
 
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/pre-authorizations"
@@ -35,12 +30,6 @@ describe Escobar::Heroku::App do
   end
 
   it "handle preauthorization failure" do
-    expect(pipeline.github_repository).to eql("atmos/slash-heroku")
-    expect(pipeline).to be_configured
-
-    production = pipeline.environments["production"]
-    app = production.first.app
-
     expect(app.name).to eql("slash-heroku-production")
 
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/pre-authorizations"
@@ -53,12 +42,6 @@ describe Escobar::Heroku::App do
   end
 
   it "handles locked applications" do
-    expect(pipeline.github_repository).to eql("atmos/slash-heroku")
-    expect(pipeline).to be_configured
-
-    production = pipeline.environments["production"]
-    app = production.first.app
-
     expect(app.name).to eql("slash-heroku-production")
 
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/config-vars"
@@ -69,12 +52,6 @@ describe Escobar::Heroku::App do
   end
 
   it "handles unlocked applications" do
-    expect(pipeline.github_repository).to eql("atmos/slash-heroku")
-    expect(pipeline).to be_configured
-
-    production = pipeline.environments["production"]
-    app = production.first.app
-
     expect(app.name).to eql("slash-heroku-production")
 
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/config-vars"


### PR DESCRIPTION
There's a bunch of code in the pipeline class that should be broken up across an `App`, `Build`, and `Release` model. This starts moving them out, but requires a decent amount of tests to still be written.