### PR TITLE
Enable easier access to a "default" application to deploy

### DIFF
--- a/lib/escobar/heroku/build_request.rb
+++ b/lib/escobar/heroku/build_request.rb
@@ -30,6 +30,10 @@ module Escobar
         Error.new_from_build_request(self, message)
       end
 
+      def cache_key
+        Digest::SHA1.hexdigest("escobar-build-request-#{app.name}")
+      end
+
       def create(task, environment, ref, forced, custom_payload)
         if app.locked?
           raise error_for("Application requires second factor: #{app.name}")

--- a/lib/escobar/heroku/build_request.rb
+++ b/lib/escobar/heroku/build_request.rb
@@ -31,7 +31,7 @@ module Escobar
       end
 
       def cache_key
-        Digest::SHA1.hexdigest("escobar-build-request-#{app.name}")
+        "escobar-build-request-#{app.name}"
       end
 
       def create(task, environment, ref, forced, custom_payload)

--- a/lib/escobar/heroku/pipeline.rb
+++ b/lib/escobar/heroku/pipeline.rb
@@ -91,14 +91,17 @@ module Escobar
         end
       end
 
-      # rubocop:disable Metrics/LineLength
-      def create_deployment(ref, environment, force = false, custom_payload = {})
+      def default_heroku_application_name(environment)
         app = environments[environment] && environments[environment].last
         unless app
           raise ArgumentError, "No '#{environment}' environment for #{name}."
         end
+        app.app
+      end
 
-        heroku_app = app.app
+      # rubocop:disable Metrics/LineLength
+      def create_deployment(ref, environment, force = false, custom_payload = {})
+        heroku_app = default_heroku_application_name(environment)
 
         build_request = heroku_app.build_request_for(self)
         heroku_build = build_request.create(

--- a/lib/escobar/heroku/pipeline.rb
+++ b/lib/escobar/heroku/pipeline.rb
@@ -91,7 +91,7 @@ module Escobar
         end
       end
 
-      def default_heroku_application_name(environment)
+      def default_heroku_application(environment)
         app = environments[environment] && environments[environment].last
         unless app
           raise ArgumentError, "No '#{environment}' environment for #{name}."
@@ -101,7 +101,7 @@ module Escobar
 
       # rubocop:disable Metrics/LineLength
       def create_deployment(ref, environment, force = false, custom_payload = {})
-        heroku_app = default_heroku_application_name(environment)
+        heroku_app = default_heroku_application(environment)
 
         build_request = heroku_app.build_request_for(self)
         heroku_build = build_request.create(

--- a/lib/escobar/heroku/pipeline.rb
+++ b/lib/escobar/heroku/pipeline.rb
@@ -99,18 +99,16 @@ module Escobar
         app.app
       end
 
-      # rubocop:disable Metrics/LineLength
-      def create_deployment(ref, environment, force = false, custom_payload = {})
+      def create_deployment(ref, environment, force = false, payload = {})
         heroku_app = default_heroku_application(environment)
 
         build_request = heroku_app.build_request_for(self)
         heroku_build = build_request.create(
-          "deploy", environment, ref, force, custom_payload
+          "deploy", environment, ref, force, payload
         )
 
         heroku_build
       end
-      # rubocop:enable Metrics/LineLength
 
       def get(path)
         response = kolkrabbi_client.get do |request|
@@ -147,17 +145,6 @@ module Escobar
           description: description
         }
         create_deployment_status(url, payload)
-      end
-
-      def create_heroku_build(app_name, sha)
-        body = {
-          source_blob: {
-            url: github_client.archive_link(sha),
-            version: sha[0..7],
-            version_description: "#{github_repository}:#{sha}"
-          }
-        }
-        client.heroku.post("/apps/#{app_name}/builds", body)
       end
 
       def github_client

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.3.pre1".freeze
+  VERSION = "0.3.3.pre2".freeze
 end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.3.pre4".freeze
+  VERSION = "0.3.3.pre5".freeze
 end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.3.pre2".freeze
+  VERSION = "0.3.3.pre3".freeze
 end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.3.pre3".freeze
+  VERSION = "0.3.3.pre4".freeze
 end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.2".freeze
+  VERSION = "0.3.3.pre1".freeze
 end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.3.pre5".freeze
+  VERSION = "0.3.3".freeze
 end

--- a/spec/lib/escobar/heroku/build_request_spec.rb
+++ b/spec/lib/escobar/heroku/build_request_spec.rb
@@ -1,0 +1,25 @@
+require_relative "../../../spec_helper"
+
+describe Escobar::Heroku::App do
+  let(:id) { "4c18c922-6eee-451c-b7c6-c76278652ccc" }
+  let(:name) { "slash-heroku" }
+  let(:client) { Escobar::Client.from_environment }
+  let(:pipeline) { Escobar::Heroku::Pipeline.new(client, id, name) }
+  let(:app) { pipeline.environments["production"].first.app }
+
+  before do
+    stub_heroku_response("/pipelines")
+
+    pipeline_path = "/pipelines/#{id}"
+    stub_heroku_response(pipeline_path)
+    stub_heroku_response("#{pipeline_path}/pipeline-couplings")
+    stub_heroku_response("/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333")
+    stub_kolkrabbi_response("#{pipeline_path}/repository")
+  end
+
+  it "has a unique cache key" do
+    build_request = app.build_request_for(pipeline)
+    expect(build_request.cache_key)
+      .to eql("escobar-build-request-slash-heroku-production")
+  end
+end

--- a/spec/lib/escobar/heroku/pipeline_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_spec.rb
@@ -79,6 +79,18 @@ describe Escobar::Heroku::Pipeline do
       expect(pipeline.required_commit_contexts).to eql(["continuous-integration/travis-ci/push"])
     end
 
+    it "returns a default heroku application name to deploy for a stage" do
+      pipeline_path = "/pipelines/#{id}"
+      stub_heroku_response(pipeline_path)
+      stub_heroku_response("#{pipeline_path}/pipeline-couplings")
+      stub_heroku_response("/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333")
+      stub_kolkrabbi_response("#{pipeline_path}/repository")
+
+      pipeline = Escobar::Heroku::Pipeline.new(client, id, name)
+      expect(pipeline.default_heroku_application("production").name)
+        .to eql("slash-heroku-production")
+    end
+
     it "create_deployment deploys a master branch" do
       pipeline_path = "/pipelines/#{id}"
       stub_heroku_response("/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333")


### PR DESCRIPTION
Pipelines have multiple "stages" and can host many applications in a "stage". This exposes the first app we get back from the heroku API so we can start using that for build requests.