### PR TITLE
Ensure the response in errors has the methods.

### DIFF
--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -3,6 +3,10 @@ module Escobar
   class Client
     # TimeoutError class when API timeouts
     class TimeoutError < StandardError
+      def self.wrap(err)
+        new(err)
+      end
+
       attr_reader :cause
       def initialize(err)
         @cause = err

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -1,6 +1,14 @@
 module Escobar
   # Top-level client for heroku
   class Client
+    # TimeoutError class when API timeouts
+    class TimeoutError < StandardError
+      attr_reader :cause
+      def initialize(err)
+        @cause = err
+        self.set_backtrace(err.backtrace)
+      end
+    end
     # Class for returning API errors to escobar clients
     class HTTPError < StandardError
       attr_accessor :body, :headers, :status

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -9,17 +9,16 @@ module Escobar
         self.set_backtrace(err.backtrace)
       end
     end
+
     # Class for returning API errors to escobar clients
     class HTTPError < StandardError
       attr_accessor :body, :headers, :status
       def self.from_response(err)
         error = new("Error from Heroku API")
 
-        if err.is_a?(Faraday::Error::ClientError)
-          error.body    = err.response[:body]
-          error.headers = err.response[:headers]
-          error.status  = err.response[:status]
-        end
+        error.body    = err.response[:body]
+        error.headers = err.response[:headers]
+        error.status  = err.response[:status]
 
         error.set_backtrace(err.backtrace)
         error

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -7,9 +7,15 @@ module Escobar
       def self.from_response(err, response)
         error = new("Error from Heroku API")
 
-        error.body    = response.body
-        error.status  = response.status
-        error.headers = response.headers
+        if response.respond_to?(:body)
+          error.body    = response.body
+        end
+        if response.respond_to?(:status)
+          error.status  = response.status
+        end
+        if response.respond_to?(:headers)
+          error.headers = response.headers
+        end
 
         error.set_backtrace(err.backtrace)
         error

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -7,14 +7,10 @@ module Escobar
       def self.from_response(err, response)
         error = new("Error from Heroku API")
 
-        if response.respond_to?(:body)
-          error.body    = response.body
-        end
-        if response.respond_to?(:status)
-          error.status  = response.status
-        end
-        if response.respond_to?(:headers)
-          error.headers = response.headers
+        if err.is_a?(Faraday::Error::ClientError)
+          error.body    = err.response[:body]
+          error.headers = err.response[:headers]
+          error.status  = err.response[:status]
         end
 
         error.set_backtrace(err.backtrace)

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -12,7 +12,7 @@ module Escobar
     # Class for returning API errors to escobar clients
     class HTTPError < StandardError
       attr_accessor :body, :headers, :status
-      def self.from_response(err, response)
+      def self.from_response(err)
         error = new("Error from Heroku API")
 
         if err.is_a?(Faraday::Error::ClientError)

--- a/lib/escobar/github/client.rb
+++ b/lib/escobar/github/client.rb
@@ -85,41 +85,45 @@ module Escobar
       end
 
       def http_method(verb, path)
-        client.send(verb) do |request|
-          request.url path
-          request.headers["Accept"] = accept_headers
-          request.headers["Content-Type"] = "application/json"
-          request.headers["Authorization"] = "token #{token}"
-          request.options.timeout = Escobar.http_timeout
-          request.options.open_timeout = Escobar.http_open_timeout
+        with_error_handling do
+          client.send(verb) do |request|
+            request.url path
+            request.headers["Accept"] = accept_headers
+            request.headers["Content-Type"] = "application/json"
+            request.headers["Authorization"] = "token #{token}"
+            request.options.timeout = Escobar.http_timeout
+            request.options.open_timeout = Escobar.http_open_timeout
+          end
         end
-      rescue Net::OpenTimeout, Faraday::TimeoutError => e
-        raise Escobar::Client::TimeoutError.new(e)
-      rescue Faraday::Error::ClientError => e
-        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       # rubocop:disable Metrics/AbcSize
       def post(path, body)
-        response = client.post do |request|
-          request.url path
-          request.headers["Accept"] = accept_headers
-          request.headers["Content-Type"] = "application/json"
-          request.headers["Authorization"] = "token #{token}"
-          request.options.timeout = Escobar.http_timeout
-          request.options.open_timeout = Escobar.http_open_timeout
-          request.body = body.to_json
-        end
+        with_error_handling do
+          response = client.post do |request|
+            request.url path
+            request.headers["Accept"] = accept_headers
+            request.headers["Content-Type"] = "application/json"
+            request.headers["Authorization"] = "token #{token}"
+            request.options.timeout = Escobar.http_timeout
+            request.options.open_timeout = Escobar.http_open_timeout
+            request.body = body.to_json
+          end
 
-        JSON.parse(response.body)
-      rescue Net::OpenTimeout, Faraday::TimeoutError => e
-        raise Escobar::Client::TimeoutError.new(e)
-      rescue Faraday::Error::ClientError => e
-        raise Escobar::Client::HTTPError.from_response(e)
+          JSON.parse(response.body)
+        end
       end
       # rubocop:enable Metrics/AbcSize
 
       private
+
+      def with_error_handling
+        yield
+      rescue Net::OpenTimeout, Faraday::TimeoutError => e
+        raise Escobar::Client::TimeoutError.wrap(e)
+      rescue Faraday::Error::ClientError => e
+        raise Escobar::Client::HTTPError.from_response(e)
+      end
 
       def client
         @client ||= Escobar.zipkin_enabled? ? zipkin_client : default_client

--- a/lib/escobar/github/client.rb
+++ b/lib/escobar/github/client.rb
@@ -79,7 +79,7 @@ module Escobar
         response = http_method(:get, path)
         JSON.parse(response.body)
       rescue StandardError => e
-        raise Escobar::Client::HTTPError.from_response(e, response)
+        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       def accept_headers
@@ -111,7 +111,7 @@ module Escobar
 
         JSON.parse(response.body)
       rescue StandardError => e
-        raise Escobar::Client::HTTPError.from_response(e, response)
+        raise Escobar::Client::HTTPError.from_response(e)
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/lib/escobar/github/client.rb
+++ b/lib/escobar/github/client.rb
@@ -78,8 +78,6 @@ module Escobar
       def get(path)
         response = http_method(:get, path)
         JSON.parse(response.body)
-      rescue StandardError => e
-        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       def accept_headers
@@ -95,6 +93,10 @@ module Escobar
           request.options.timeout = Escobar.http_timeout
           request.options.open_timeout = Escobar.http_open_timeout
         end
+      rescue Net::OpenTimeout, Faraday::TimeoutError => e
+        raise Escobar::Client::TimeoutError.new(e)
+      rescue Faraday::Error::ClientError => e
+        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       # rubocop:disable Metrics/AbcSize
@@ -110,7 +112,9 @@ module Escobar
         end
 
         JSON.parse(response.body)
-      rescue StandardError => e
+      rescue Net::OpenTimeout, Faraday::TimeoutError => e
+        raise Escobar::Client::TimeoutError.new(e)
+      rescue Faraday::Error::ClientError => e
         raise Escobar::Client::HTTPError.from_response(e)
       end
       # rubocop:enable Metrics/AbcSize

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -27,6 +27,8 @@ module Escobar
         end
 
         JSON.parse(response.body)
+      rescue Net::OpenTimeout => e
+        raise Escobar::Client::TimeoutError.new(e)
       rescue StandardError => e
         raise Escobar::Client::HTTPError.from_response(e, response)
       end

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -3,10 +3,9 @@ module Escobar
   module Heroku
     # Top-level client for interacting with Heroku API
     class Client
-      attr_reader :client, :token
+      attr_reader :token
       def initialize(token)
         @token = token
-        @client = Escobar.zipkin_enabled? ? zipkin_client : default_client
       end
 
       # mask password
@@ -72,6 +71,10 @@ module Escobar
       end
 
       private
+
+      def client
+        @client ||= Escobar.zipkin_enabled? ? zipkin_client : default_client
+      end
 
       def request_defaults(request, version = 3)
         request.headers["Accept"]          = heroku_accept_header(version)

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -26,9 +26,9 @@ module Escobar
         end
 
         JSON.parse(response.body)
-      rescue Net::OpenTimeout => e
+      rescue Net::OpenTimeout, Faraday::TimeoutError => e
         raise Escobar::Client::TimeoutError.new(e)
-      rescue StandardError => e
+      rescue Faraday::Error::ClientError => e
         raise Escobar::Client::HTTPError.from_response(e)
       end
 
@@ -40,7 +40,9 @@ module Escobar
         end
 
         JSON.parse(response.body)
-      rescue StandardError => e
+      rescue Net::OpenTimeout, Faraday::TimeoutError => e
+        raise Escobar::Client::TimeoutError.new(e)
+      rescue Faraday::Error::ClientError => e
         raise Escobar::Client::HTTPError.from_response(e)
       end
 
@@ -52,7 +54,9 @@ module Escobar
         end
 
         JSON.parse(response.body)
-      rescue StandardError => e
+      rescue Net::OpenTimeout, Faraday::TimeoutError => e
+        raise Escobar::Client::TimeoutError.new(e)
+      rescue Faraday::Error::ClientError => e
         raise Escobar::Client::HTTPError.from_response(e)
       end
 
@@ -66,7 +70,9 @@ module Escobar
         end
 
         JSON.parse(response.body)
-      rescue StandardError => e
+      rescue Net::OpenTimeout, Faraday::TimeoutError => e
+        raise Escobar::Client::TimeoutError.new(e)
+      rescue Faraday::Error::ClientError => e
         raise Escobar::Client::HTTPError.from_response(e)
       end
 

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -6,6 +6,7 @@ module Escobar
       attr_reader :client, :token
       def initialize(token)
         @token = token
+        @client = Escobar.zipkin_enabled? ? zipkin_client : default_client
       end
 
       # mask password
@@ -83,10 +84,6 @@ module Escobar
 
       def heroku_accept_header(version)
         "application/vnd.heroku+json; version=#{version}"
-      end
-
-      def client
-        @client ||= Escobar.zipkin_enabled? ? zipkin_client : default_client
       end
 
       def zipkin_client

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -30,7 +30,7 @@ module Escobar
       rescue Net::OpenTimeout => e
         raise Escobar::Client::TimeoutError.new(e)
       rescue StandardError => e
-        raise Escobar::Client::HTTPError.from_response(e, response)
+        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       def get_range(path, range, version = 3)
@@ -42,7 +42,7 @@ module Escobar
 
         JSON.parse(response.body)
       rescue StandardError => e
-        raise Escobar::Client::HTTPError.from_response(e, response)
+        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       def post(path, body)
@@ -54,7 +54,7 @@ module Escobar
 
         JSON.parse(response.body)
       rescue StandardError => e
-        raise Escobar::Client::HTTPError.from_response(e, response)
+        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       def put(path, second_factor = nil)
@@ -68,7 +68,7 @@ module Escobar
 
         JSON.parse(response.body)
       rescue StandardError => e
-        raise Escobar::Client::HTTPError.from_response(e, response)
+        raise Escobar::Client::HTTPError.from_response(e)
       end
 
       private

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.14".freeze
+  VERSION = "0.3.15".freeze
 end

--- a/spec/lib/escobar/client_spec.rb
+++ b/spec/lib/escobar/client_spec.rb
@@ -51,22 +51,4 @@ describe Escobar::Client do
     end
   end
   # rubocop:enable Metrics/LineLength
-
-  it "wraps http exceptions well" do
-    err = ArgumentError.new("Missing some stuff")
-
-    response_body    = { id: "two_factor", message: "Missing 2fa" }.to_json
-    response_headers = { offset: "1" }
-    stub_request(:get, "https://heroku.com").to_return(
-      status: 403, body: response_body, headers: response_headers
-    )
-
-    response = Faraday.get "https://heroku.com"
-
-    exception = Escobar::Client::HTTPError.from_response(err, response)
-    expect(exception.status).to eql(403)
-    expect(exception.body).to eql(
-      "{\"id\":\"two_factor\",\"message\":\"Missing 2fa\"}"
-    )
-  end
 end

--- a/spec/lib/escobar/heroku/client_spec.rb
+++ b/spec/lib/escobar/heroku/client_spec.rb
@@ -1,0 +1,27 @@
+require "spec_helper"
+
+RSpec.describe Escobar::Heroku::Client do
+  let(:client) { Escobar::Heroku::Client.new("123") }
+  it "should rescue timeout errors" do
+    expect(client.client).to receive(:get).and_raise(Net::OpenTimeout)
+    expect do
+      client.get("/account")
+    end.to raise_error(Escobar::Client::TimeoutError)
+  end
+
+  it "should correctly handle response from a Faraday ClientError" do
+    faraday_error = Faraday::Error::ClientError.new("message", {
+      body: "body",
+      headers: { something: true },
+      status: 502
+    })
+    expect(client.client).to receive(:get).and_raise(faraday_error)
+    expect do
+      client.get("/account")
+    end.to raise_error(Escobar::Client::HTTPError) do |e|
+      expect(e.body).to eql("body")
+      expect(e.headers).to eql({something: true})
+      expect(e.status).to eql(502)
+    end
+  end
+end

--- a/spec/lib/escobar/heroku/client_spec.rb
+++ b/spec/lib/escobar/heroku/client_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Escobar::Heroku::Client do
   let(:client) { Escobar::Heroku::Client.new("123") }
   it "should rescue timeout errors" do
-    expect(client.client).to receive(:get).and_raise(Net::OpenTimeout)
+    stub_request(:get, "https://api.heroku.com/account").to_timeout
     expect do
       client.get("/account")
     end.to raise_error(Escobar::Client::TimeoutError)
@@ -15,7 +15,8 @@ RSpec.describe Escobar::Heroku::Client do
       headers: { something: true },
       status: 502
     })
-    expect(client.client).to receive(:get).and_raise(faraday_error)
+    stub_request(:get, "https://api.heroku.com/account")
+      .to_raise(faraday_error)
     expect do
       client.get("/account")
     end.to raise_error(Escobar::Client::HTTPError) do |e|

--- a/spec/lib/escobar/heroku/client_spec.rb
+++ b/spec/lib/escobar/heroku/client_spec.rb
@@ -10,18 +10,20 @@ RSpec.describe Escobar::Heroku::Client do
   end
 
   it "should correctly handle response from a Faraday ClientError" do
-    faraday_error = Faraday::Error::ClientError.new("message", {
+    faraday_error = Faraday::Error::ClientError.new(
+      "message",
       body: "body",
-      headers: { something: true },
+      headers: {
+        something: true
+      },
       status: 502
-    })
+    )
     stub_request(:get, "https://api.heroku.com/account")
       .to_raise(faraday_error)
-    expect do
-      client.get("/account")
-    end.to raise_error(Escobar::Client::HTTPError) do |e|
+    expect { client.get("/account") }
+      .to raise_error(Escobar::Client::HTTPError) do |e|
       expect(e.body).to eql("body")
-      expect(e.headers).to eql({something: true})
+      expect(e.headers).to eql(something: true)
       expect(e.status).to eql(502)
     end
   end


### PR DESCRIPTION
If we raise in the Faraday call, response is probably nil and so we don't have access to
`body`, `status` or `headers`

This ensures that `response` responds to the methods we want.