### PR TITLE
Ignores runs dynos as they are one offs

### DIFF
--- a/lib/escobar/heroku/dynos.rb
+++ b/lib/escobar/heroku/dynos.rb
@@ -17,14 +17,18 @@ module Escobar
         @info ||= client.heroku.get("/apps/#{app_id}/dynos")
       end
 
+      def non_one_off
+        info.reject { |dyno| dyno["type"] == "run" }
+      end
+
       def running?(release_id)
-        info.all? do |dyno|
+        non_one_off.all? do |dyno|
           dyno["release"]["id"] == release_id && dyno["state"] == "up"
         end
       end
 
       def newer_than?(epoch)
-        info.all? do |dyno|
+        non_one_off.all? do |dyno|
           epoch < Time.parse(dyno["created_at"]).utc
         end
       end

--- a/spec/fixtures/api.heroku.com/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/dynos-with-runs.json
+++ b/spec/fixtures/api.heroku.com/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/dynos-with-runs.json
@@ -1,0 +1,59 @@
+[
+  {
+    "attach_url":null,
+    "command":"bundle exec puma -C config/puma.rb",
+    "created_at":"2017-02-06T08:03:17Z",
+    "id":"b5e05c87-1e82-44b4-b9d8-14ba952f146c",
+    "name":"web.1",
+    "app":{
+      "id":"7bd2a1ac-1ed2-4fc5-b374-6c2ca276c340",
+      "name":"slash-heroku"
+    },
+    "release":{
+      "id":"715b6e1d-542b-40e1-9c7b-3d3128e78873",
+      "version":80
+    },
+    "size":"Standard-1X",
+    "state":"up",
+    "type":"web",
+    "updated_at":"2017-02-06T08:03:17Z"
+  },
+  {
+    "attach_url":null,
+    "command":"/usr/bin/env LIBRATO_AUTORUN=1 bundle exec sidekiq",
+    "created_at":"2017-02-06T04:36:53Z",
+    "id":"0eee5c26-9034-4869-9f9e-5877b3cbb7fb",
+    "name":"worker.1",
+    "app":{
+      "id":"7bd2a1ac-1ed2-4fc5-b374-6c2ca276c340",
+      "name":"slash-heroku"
+    },
+    "release":{
+      "id":"715b6e1d-542b-40e1-9c7b-3d3128e78873",
+      "version":80
+    },
+    "size":"Standard-1X",
+    "state":"up",
+    "type":"worker",
+    "updated_at":"2017-02-06T04:36:53Z"
+  },
+  {
+    "attach_url":null,
+    "command":"/usr/bin/env LIBRATO_AUTORUN=1 bundle exec sidekiq",
+    "created_at":"2017-02-06T04:36:53Z",
+    "id":"0eee5c26-9034-4869-9f9e-5877b3cbb7fb",
+    "name":"run.1",
+    "app":{
+      "id":"7bd2a1ac-1ed2-4fc5-b374-6c2ca276c340",
+      "name":"slash-heroku"
+    },
+    "release":{
+      "id": "fdd4dc40-16eb-4512-a618-8c38f28dd02e",
+      "version":79
+    },
+    "size":"Standard-1X",
+    "state":"up",
+    "type":"run",
+    "updated_at":"2017-02-06T04:36:53Z"
+  }
+]

--- a/spec/lib/escobar/heroku/dynos_spec.rb
+++ b/spec/lib/escobar/heroku/dynos_spec.rb
@@ -36,4 +36,18 @@ describe Escobar::Heroku::Dynos do
 
     expect(dynos).to be_running("715b6e1d-542b-40e1-9c7b-3d3128e78873")
   end
+
+  it "ignores run dynos" do
+    path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/dynos"
+    stub_request(:get, "https://api.heroku.com#{path}")
+      .with(headers: default_heroku_headers)
+      .to_return(
+        status: 200, body: fixture_data("api.heroku.com#{path}-with-runs")
+      )
+
+    expect(dynos).to be_newer_than(Time.parse("2017-02-05T08:03:17Z").utc)
+    expect(dynos).to_not be_newer_than(Time.parse("2017-02-06T08:03:17Z").utc)
+
+    expect(dynos).to be_running("715b6e1d-542b-40e1-9c7b-3d3128e78873")
+  end
 end


### PR DESCRIPTION
One off dynos could keep on running an old version.
Right now we care about every dynos.

Those dynos could run for a day before dying.

This takes that information into account and will help for releases of apps that have background tasks running.