### PR TITLE
Don't process pipeline stages of 'test'

### DIFF
--- a/lib/escobar/heroku/pipeline.rb
+++ b/lib/escobar/heroku/pipeline.rb
@@ -47,10 +47,14 @@ module Escobar
       end
 
       def couplings
-        @couplings ||= couplings!
+        @couplings ||= remote_couplings_with_test_stage
       end
 
-      def couplings!
+      def remote_couplings_with_test_stage
+        remote_couplings.reject { |coupling| coupling.stage == "test" }
+      end
+
+      def remote_couplings
         client.heroku.get("/pipelines/#{id}/pipeline-couplings").map do |pc|
           Escobar::Heroku::Coupling.new(client, pc)
         end

--- a/lib/escobar/heroku/pipeline.rb
+++ b/lib/escobar/heroku/pipeline.rb
@@ -47,10 +47,10 @@ module Escobar
       end
 
       def couplings
-        @couplings ||= remote_couplings_with_test_stage
+        @couplings ||= remote_couplings_without_test_stage
       end
 
-      def remote_couplings_with_test_stage
+      def remote_couplings_without_test_stage
         remote_couplings.reject { |coupling| coupling.stage == "test" }
       end
 

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.16".freeze
+  VERSION = "0.3.17".freeze
 end

--- a/spec/fixtures/api.heroku.com/apps/760bc95e-8780-4c76-a999-3a4af92a3eee.json
+++ b/spec/fixtures/api.heroku.com/apps/760bc95e-8780-4c76-a999-3a4af92a3eee.json
@@ -1,0 +1,34 @@
+{
+  "archived_at": null,
+  "buildpack_provided_description": "Ruby",
+  "build_stack": {
+    "id": "f9f9cbd7-2970-41ef-8db5-3df7123b041f",
+    "name": "cedar-14"
+  },
+  "created_at": "2016-03-14T04:58:27Z",
+  "id": "760bc95e-8780-4c76-a999-3a4af92a3eee",
+  "git_url": "https://git.heroku.com/slash-heroku-ci-whatever.git",
+  "maintenance": false,
+  "name": "slash-heroku-ci-whatever",
+  "owner": {
+    "email": "heroku-tools@herokumanager.com",
+    "id": "9bdd664f-3d97-41d5-a946-77eb03cd193f"
+  },
+  "region": {
+    "id": "3544427c-5b3b-4e1e-b01a-b66362573b26",
+    "name": "virginia"
+  },
+  "space": {
+    "id": "706d84bb-9476-46b8-b6a5-1b62670bddf1",
+    "name": "heroku-tools"
+  },
+  "released_at": "2016-03-16T12:45:50Z",
+  "repo_size": 20669358,
+  "slug_size": 53199721,
+  "stack": {
+    "id": "f9f9cbd7-2970-41ef-8db5-3df7123b041f",
+    "name": "cedar-14"
+  },
+  "updated_at": "2016-03-16T12:45:50Z",
+  "web_url": "http://slash-heroku-ci-whatever.herokuapp.com/"
+}

--- a/spec/fixtures/api.heroku.com/pipelines/4c18c922-6eee-451c-b7c6-c76278652ccc/pipeline-couplings.json
+++ b/spec/fixtures/api.heroku.com/pipelines/4c18c922-6eee-451c-b7c6-c76278652ccc/pipeline-couplings.json
@@ -24,5 +24,18 @@
     },
     "stage": "staging",
     "updated_at": "2016-03-14T07:53:56+00:00"
+  },
+  {
+    "created_at": "2016-03-14T07:53:56+00:00",
+    "app": {
+      "id": "760bc95e-8780-4c76-a999-3a4af92a3eee"
+    },
+    "id": "69648ef0-80f1-4311-b81e-9993d25d1fd6",
+    "pipeline": {
+      "id": "4c18c922-6eee-451c-b7c6-c76278652ccc",
+      "name": "slash-heroku"
+    },
+    "stage": "test",
+    "updated_at": "2016-03-14T07:53:56+00:00"
   }
 ]

--- a/spec/lib/escobar/heroku/pipeline_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_spec.rb
@@ -95,6 +95,8 @@ describe Escobar::Heroku::Pipeline do
       pipeline_path = "/pipelines/#{id}"
       stub_heroku_response("/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333")
       stub_heroku_response("/apps/760bc95e-8780-4c76-a688-3a4af92a3eee")
+      stub_heroku_response("/apps/760bc95e-8780-4c76-a999-3a4af92a3eee")
+
       stub_heroku_response(pipeline_path)
       stub_heroku_response("#{pipeline_path}/pipeline-couplings")
       stub_kolkrabbi_response("#{pipeline_path}/repository")


### PR DESCRIPTION
The default environment method could sometimes get tripped up if heroku-ci is running while you make a deployment request that infers the environment to deploy to.

There's no reason to include the test stage in this library so the coupling is plucked when the the available stages are fetched from the API.