### PR TITLE
App log url and direct to drain support

### DIFF
--- a/lib/escobar/heroku/app.rb
+++ b/lib/escobar/heroku/app.rb
@@ -58,12 +58,10 @@ module Escobar
       end
 
       def direct_to_drain?
-        response = client.heroku.get("/apps/#{id}/log-drains")
-        response["id"] == "two_factor" &&
-          response["message"].match(/"This Private Space uses direct logging/)
+        client.heroku.get("/apps/#{id}/log-drains").any?
       rescue Escobar::Heroku::Client::HTTPError => e
         response = JSON.parse(e.response.body)
-        response["id"] == "two_factor" &&
+        response["id"] == "forbidden" &&
           response["message"].match(/"This Private Space uses direct logging/)
       end
 

--- a/lib/escobar/heroku/app.rb
+++ b/lib/escobar/heroku/app.rb
@@ -57,6 +57,20 @@ module Escobar
         response["id"] == "two_factor"
       end
 
+      def direct_to_drain?
+        response = client.heroku.get("/apps/#{id}/log-drains")
+        response["id"] == "two_factor" &&
+          response["message"].match(/"This Private Space uses direct logging/)
+      rescue Escobar::Heroku::Client::HTTPError => e
+        response = JSON.parse(e.response.body)
+        response["id"] == "two_factor" &&
+          response["message"].match(/"This Private Space uses direct logging/)
+      end
+
+      def log_url
+        @log_url ||= "#{dashboard_url}/logs"
+      end
+
       def build_request_for(pipeline)
         Escobar::Heroku::BuildRequest.new(pipeline, id)
       end

--- a/lib/escobar/heroku/app.rb
+++ b/lib/escobar/heroku/app.rb
@@ -52,17 +52,21 @@ module Escobar
       def locked?
         response = client.heroku.get("/apps/#{id}/config-vars")
         response["id"] == "two_factor"
-      rescue Escobar::Heroku::Client::HTTPError => e
+      rescue Escobar::Client::HTTPError => e
         response = JSON.parse(e.response.body)
         response["id"] == "two_factor"
       end
 
       def direct_to_drain?
-        client.heroku.get("/apps/#{id}/log-drains").any?
-      rescue Escobar::Heroku::Client::HTTPError => e
+        response = client.heroku.get("/apps/#{id}/log-drains")
+        response["id"] == "forbidden" &&
+          response["message"].match(/This Private Space uses direct logging/)
+      rescue TypeError
+        false
+      rescue Escobar::Client::HTTPError => e
         response = JSON.parse(e.response.body)
         response["id"] == "forbidden" &&
-          response["message"].match(/"This Private Space uses direct logging/)
+          response["message"].match(/This Private Space uses direct logging/)
       end
 
       def log_url

--- a/lib/escobar/heroku/app.rb
+++ b/lib/escobar/heroku/app.rb
@@ -59,10 +59,7 @@ module Escobar
 
       def direct_to_drain?
         response = client.heroku.get("/apps/#{id}/log-drains")
-        response["id"] == "forbidden" &&
-          response["message"].match(/This Private Space uses direct logging/)
-      rescue TypeError
-        false
+        !response.is_a?(Array)
       rescue Escobar::Client::HTTPError => e
         response = JSON.parse(e.response.body)
         response["id"] == "forbidden" &&

--- a/spec/lib/escobar/heroku/app_spec.rb
+++ b/spec/lib/escobar/heroku/app_spec.rb
@@ -71,6 +71,28 @@ describe Escobar::Heroku::App do
       .to eql("https://dashboard.heroku.com/apps/slash-heroku-production/logs")
   end
 
+  it "detects direct to drain logging enabled" do
+    path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/log-drains"
+    failure_message = {
+      id: "forbidden",
+      message: "This Private Space uses direct logging which " \
+               "is incompatible with this feature."
+    }
+    stub_request(:get, "https://api.heroku.com#{path}")
+      .with(headers: default_heroku_headers)
+      .to_return(status: 403, body: failure_message.to_json)
+
+    expect(app).to be_direct_to_drain
+  end
+
+  it "detects log drains are enanled" do
+    path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/log-drains"
+    stub_request(:get, "https://api.heroku.com#{path}")
+      .with(headers: default_heroku_headers)
+      .to_return(status: 200, body: [].to_json)
+    expect(app).to_not be_direct_to_drain
+  end
+
   it "lists releases" do
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/releases"
     stub_request(:get, "https://api.heroku.com#{path}")

--- a/spec/lib/escobar/heroku/app_spec.rb
+++ b/spec/lib/escobar/heroku/app_spec.rb
@@ -66,6 +66,11 @@ describe Escobar::Heroku::App do
       .to eql("escobar-app-b0deddbf-cf56-48e4-8c3a-3ea143be2333")
   end
 
+  it "has a log url" do
+    expect(app.log_url)
+      .to eql("https://dashboard.heroku.com/apps/slash-heroku-production/logs")
+  end
+
   it "lists releases" do
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/releases"
     stub_request(:get, "https://api.heroku.com#{path}")


### PR DESCRIPTION
This supports two private spaces features we need in order to provide log urls for cedar and private space applications.