### PR TITLE
Required contexts missing raise an exception

### DIFF
--- a/lib/escobar.rb
+++ b/lib/escobar.rb
@@ -60,6 +60,7 @@ end
 
 require_relative "./escobar/client"
 require_relative "./escobar/github/client"
+require_relative "./escobar/github/deployment_error"
 require_relative "./escobar/heroku/app"
 require_relative "./escobar/heroku/build"
 require_relative "./escobar/heroku/build_request"

--- a/lib/escobar/github/deployment_error.rb
+++ b/lib/escobar/github/deployment_error.rb
@@ -1,0 +1,37 @@
+module Escobar
+  module GitHub
+    # Consolidate GitHub deployment api failures for easier messaging
+    class DeploymentError < StandardError
+      attr_accessor :repo, :response, :required_commit_contexts
+
+      def initialize(repo, response, required_commit_contexts)
+        @repo = repo
+        @response = response
+        @required_commit_contexts = required_commit_contexts
+      end
+
+      def missing_contexts?
+        missing_contexts.any?
+      end
+
+      def missing_contexts
+        error = response.fetch("errors", [])[0]
+        return [] unless error && error["field"] == "required_contexts"
+        contexts = error["contexts"]
+        contexts.each_with_object([]) do |context, missing|
+          failed = (context["state"] != "success")
+          required = required_commit_contexts.include?(context["context"])
+          missing << context["context"] if required && failed
+        end
+      end
+
+      def response_message
+        response["message"]
+      end
+
+      def default_message
+        "Unable to create GitHub deployments for #{repo}: #{response_message}"
+      end
+    end
+  end
+end

--- a/lib/escobar/heroku/build_request.rb
+++ b/lib/escobar/heroku/build_request.rb
@@ -17,6 +17,7 @@ module Escobar
         end
       end
 
+      # Class representing a rejected GitHub deployment
       class MissingContextsError < Error
         attr_accessor :missing_contexts
       end
@@ -113,13 +114,10 @@ module Escobar
         msg = "Unable to create GitHub deployments for " \
           "#{pipeline.github_repository}: #{response['message']}"
         missing = missing_contexts(response)
-        if missing.any?
-          err = MissingContextsError.new_from_build_request(self, msg)
-          err.missing_contexts = missing
-          raise err
-        else
-          raise error_for(msg)
-        end
+        raise error_for(msg) unless missing.any?
+        err = MissingContextsError.new_from_build_request(self, msg)
+        err.missing_contexts = missing
+        raise err
       end
 
       def missing_contexts(response)

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.20".freeze
+  VERSION = "0.3.21".freeze
 end

--- a/spec/fixtures/api.github.com/repos/atmos/slash-heroku/required_contexts.json
+++ b/spec/fixtures/api.github.com/repos/atmos/slash-heroku/required_contexts.json
@@ -1,0 +1,25 @@
+{
+    "documentation_url": "https://developer.github.com/v3/repos/deployments/#create-a-deployment",
+    "errors": [
+        {
+            "code": "invalid",
+            "contexts": [
+                {
+                    "context": "heroku/compliance",
+                    "state": "pending"
+                },
+                {
+                    "context": "vulnerabilities/gems",
+                    "state": "success"
+                },
+                {
+                    "context": "continuous-integration/heroku",
+                    "state": "pending"
+                }
+            ],
+            "field": "required_contexts",
+            "resource": "Deployment"
+        }
+    ],
+    "message": "Conflict: Commit status checks failed for less-buttons."
+}

--- a/spec/fixtures/api.github.com/repos/atmos/slash-heroku/required_contexts.json
+++ b/spec/fixtures/api.github.com/repos/atmos/slash-heroku/required_contexts.json
@@ -5,16 +5,12 @@
             "code": "invalid",
             "contexts": [
                 {
-                    "context": "heroku/compliance",
+                    "context": "continuous-integration/travis-ci/push",
                     "state": "pending"
                 },
                 {
                     "context": "vulnerabilities/gems",
                     "state": "success"
-                },
-                {
-                    "context": "continuous-integration/heroku",
-                    "state": "pending"
                 }
             ],
             "field": "required_contexts",

--- a/spec/lib/escobar/heroku/pipeline_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_spec.rb
@@ -213,6 +213,41 @@ describe Escobar::Heroku::Pipeline do
           "Application requires second factor: slash-heroku-production"
         )
     end
+
+    it "raises a MissingContextsError if required contexts are missing" do
+      pipeline_path = "/pipelines/#{id}"
+      stub_heroku_response("/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333")
+      stub_heroku_response("/apps/760bc95e-8780-4c76-a688-3a4af92a3eee")
+      stub_heroku_response(pipeline_path)
+      stub_heroku_response("#{pipeline_path}/pipeline-couplings")
+      stub_kolkrabbi_response("#{pipeline_path}/repository")
+
+      stub_request(:get, "https://api.heroku.com/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/config-vars")
+        .to_return(status: 200, body: { "RACK_ENV": "production" }.to_json, headers: {})
+
+      response = fixture_data("api.github.com/repos/atmos/slash-heroku/index")
+      stub_request(:get, "https://api.github.com/repos/atmos/slash-heroku")
+        .with(headers: default_github_headers)
+        .to_return(status: 200, body: response, headers: {})
+
+      response = fixture_data("api.github.com/repos/atmos/slash-heroku/branches/master")
+      stub_request(:get, "https://api.github.com/repos/atmos/slash-heroku/branches/master")
+        .with(headers: default_github_headers)
+        .to_return(status: 200, body: response, headers: {})
+
+      response = fixture_data("api.github.com/repos/atmos/slash-heroku/required_contexts")
+      stub_request(:post, "https://api.github.com/repos/atmos/slash-heroku/deployments")
+        .with(headers: default_github_headers)
+        .to_return(status: 409, body: response, headers: {})
+
+      pipeline = Escobar::Heroku::Pipeline.new(client, id, name)
+      expect { pipeline.create_deployment("master", "production") }
+        .to raise_error(Escobar::Heroku::BuildRequest::MissingContextsError) do |err|
+        expect(err.missing_contexts)
+          .to eql(["continuous-integration/travis-ci/push"])
+
+      end
+    end
     # rubocop:enable Metrics/LineLength
   end
 end

--- a/spec/lib/escobar/heroku/pipeline_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_spec.rb
@@ -245,7 +245,6 @@ describe Escobar::Heroku::Pipeline do
         .to raise_error(Escobar::Heroku::BuildRequest::MissingContextsError) do |err|
         expect(err.missing_contexts)
           .to eql(["continuous-integration/travis-ci/push"])
-
       end
     end
     # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
When you try to deploy a branch that has required contexts and some of them are missing, 
This change will make it raise a `MissingContextsError` that has a `missing_contexts` attribute containing the list of the missing contexts.

## Why?

Our usage of Escobar does not allow us right now to show which contexts are missing and are showing just the error message.
This will make that error more explicit in chat.