### PR TITLE
Missing = required - succeeded contexts

### DIFF
--- a/lib/escobar/github/deployment_error.rb
+++ b/lib/escobar/github/deployment_error.rb
@@ -14,15 +14,19 @@ module Escobar
         missing_contexts.any?
       end
 
-      def missing_contexts
+      def succeeded_required_contexts
         error = response.fetch("errors", [])[0]
         return [] unless error && error["field"] == "required_contexts"
         contexts = error["contexts"]
-        contexts.each_with_object([]) do |context, missing|
-          failed = (context["state"] != "success")
+        contexts.each_with_object([]) do |context, succeeded|
+          success = (context["state"] == "success")
           required = required_commit_contexts.include?(context["context"])
-          missing << context["context"] if required && failed
+          succeeded << context["context"] if required && success
         end
+      end
+
+      def missing_contexts
+        required_commit_contexts - succeeded_required_contexts
       end
 
       def response_message

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.3.21".freeze
+  VERSION = "0.3.22".freeze
 end

--- a/spec/fixtures/api.github.com/repos/atmos/slash-heroku/required_contexts_not_present.json
+++ b/spec/fixtures/api.github.com/repos/atmos/slash-heroku/required_contexts_not_present.json
@@ -1,0 +1,17 @@
+{
+    "documentation_url": "https://developer.github.com/v3/repos/deployments/#create-a-deployment",
+    "errors": [
+        {
+            "code": "invalid",
+            "contexts": [
+                {
+                    "context": "vulnerabilities/gems",
+                    "state": "success"
+                }
+            ],
+            "field": "required_contexts",
+            "resource": "Deployment"
+        }
+    ],
+    "message": "Conflict: Commit status checks failed for less-buttons."
+}

--- a/spec/lib/escobar/heroku/pipeline_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_spec.rb
@@ -214,7 +214,7 @@ describe Escobar::Heroku::Pipeline do
         )
     end
 
-    it "raises a MissingContextsError if required contexts are missing" do
+    it "raises a MissingContextsError if required contexts are failed" do
       pipeline_path = "/pipelines/#{id}"
       stub_heroku_response("/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333")
       stub_heroku_response("/apps/760bc95e-8780-4c76-a688-3a4af92a3eee")
@@ -236,6 +236,40 @@ describe Escobar::Heroku::Pipeline do
         .to_return(status: 200, body: response, headers: {})
 
       response = fixture_data("api.github.com/repos/atmos/slash-heroku/required_contexts")
+      stub_request(:post, "https://api.github.com/repos/atmos/slash-heroku/deployments")
+        .with(headers: default_github_headers)
+        .to_return(status: 409, body: response, headers: {})
+
+      pipeline = Escobar::Heroku::Pipeline.new(client, id, name)
+      expect { pipeline.create_deployment("master", "production") }
+        .to raise_error(Escobar::Heroku::BuildRequest::MissingContextsError) do |err|
+        expect(err.missing_contexts)
+          .to eql(["continuous-integration/travis-ci/push"])
+      end
+    end
+
+    it "raises a MissingContextsError if required contexts are not present in payload" do
+      pipeline_path = "/pipelines/#{id}"
+      stub_heroku_response("/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333")
+      stub_heroku_response("/apps/760bc95e-8780-4c76-a688-3a4af92a3eee")
+      stub_heroku_response(pipeline_path)
+      stub_heroku_response("#{pipeline_path}/pipeline-couplings")
+      stub_kolkrabbi_response("#{pipeline_path}/repository")
+
+      stub_request(:get, "https://api.heroku.com/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/config-vars")
+        .to_return(status: 200, body: { "RACK_ENV": "production" }.to_json, headers: {})
+
+      response = fixture_data("api.github.com/repos/atmos/slash-heroku/index")
+      stub_request(:get, "https://api.github.com/repos/atmos/slash-heroku")
+        .with(headers: default_github_headers)
+        .to_return(status: 200, body: response, headers: {})
+
+      response = fixture_data("api.github.com/repos/atmos/slash-heroku/branches/master")
+      stub_request(:get, "https://api.github.com/repos/atmos/slash-heroku/branches/master")
+        .with(headers: default_github_headers)
+        .to_return(status: 200, body: response, headers: {})
+
+      response = fixture_data("api.github.com/repos/atmos/slash-heroku/required_contexts_not_present")
       stub_request(:post, "https://api.github.com/repos/atmos/slash-heroku/deployments")
         .with(headers: default_github_headers)
         .to_return(status: 409, body: response, headers: {})


### PR DESCRIPTION
By detecting failing contexts only, if present in the current list of contexts, we are missing the ones that are not present.

For example, green CI is only available on the last push of a group of commits, it is not run for every commit.

This ensures that we only ship something that has all the required contexts, instead of just showing missing ones that are failed or pending.