### PR TITLE
We weren't using the forced attribute 

### DIFF
--- a/lib/escobar/heroku/pipeline_promotion_request.rb
+++ b/lib/escobar/heroku/pipeline_promotion_request.rb
@@ -109,7 +109,7 @@ module Escobar
       end
 
       def required_commit_contexts
-        pipeline.required_commit_contexts(false)
+        pipeline.required_commit_contexts(forced)
       end
 
       def handle_github_deployment_response(response)

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.2".freeze
+  VERSION = "0.4.3".freeze
 end

--- a/spec/lib/escobar/heroku/pipeline_promotion_request_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_promotion_request_spec.rb
@@ -65,7 +65,7 @@ describe Escobar::Heroku::PipelinePromotionRequest do
       .with(headers: default_github_headers)
       .to_return(status: 200, body: response, headers: {})
 
-    releases = pipeline.promote(app, targets, "production", {})
+    releases = pipeline.promote(app, targets, "production")
     expect(releases).to_not be_empty
     expect(releases.first.status).to eql("succeeded")
   end
@@ -97,7 +97,7 @@ describe Escobar::Heroku::PipelinePromotionRequest do
       .to_return(status: 403, body: response, headers: {})
 
     expect do
-      pipeline.promote(app, targets, "production", {})
+      pipeline.promote(app, targets, "production")
     end.to raise_error(Escobar::Heroku::PipelinePromotion::RequiresTwoFactorError)
   end
 
@@ -128,7 +128,7 @@ describe Escobar::Heroku::PipelinePromotionRequest do
       .to_return(status: 403, body: response, headers: {})
 
     expect do
-      pipeline.promote(app, targets, "production", {})
+      pipeline.promote(app, targets, "production")
     end.to raise_error(Escobar::Heroku::PipelinePromotion::MissingContextsError)
   end
   # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
so required contexts were always required