### PR TITLE
Fail on 2fa failure

### DIFF
--- a/lib/escobar/heroku/pipeline_promotion_request.rb
+++ b/lib/escobar/heroku/pipeline_promotion_request.rb
@@ -35,8 +35,8 @@ module Escobar
         handle_github_deployment_statuses_for(releases)
         releases
       rescue PipelinePromotion::RequiresTwoFactorError
-       handle_2fa_failure
-       raise
+        handle_2fa_failure
+        raise
       end
 
       def handle_2fa_failure

--- a/lib/escobar/heroku/pipeline_promotion_request.rb
+++ b/lib/escobar/heroku/pipeline_promotion_request.rb
@@ -34,6 +34,20 @@ module Escobar
         releases = promotion.create
         handle_github_deployment_statuses_for(releases)
         releases
+      rescue PipelinePromotion::RequiresTwoFactorError
+       handle_2fa_failure
+       raise
+      end
+
+      def handle_2fa_failure
+        target_urls.values.each do |target_url|
+          create_github_deployment_status(
+            target_url,
+            nil,
+            "failed",
+            "Missing second factor"
+          )
+        end
       end
 
       def handle_github_deployment_statuses_for(releases)

--- a/lib/escobar/heroku/pipeline_promotion_request.rb
+++ b/lib/escobar/heroku/pipeline_promotion_request.rb
@@ -44,7 +44,7 @@ module Escobar
           create_github_deployment_status(
             target_url,
             nil,
-            "failed",
+            "error",
             "Missing second factor"
           )
         end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.3".freeze
+  VERSION = "0.4.4".freeze
 end

--- a/spec/fixtures/api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses/error-1.json
+++ b/spec/fixtures/api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses/error-1.json
@@ -1,7 +1,7 @@
 {
   "url": "https://api.github.com/repos/atmos/slash-heroku/deployments/22233197/statuses/38999643",
   "id": 38999643,
-  "state": "failed",
+  "state": "error",
   "creator": {
     "login": "atmos",
     "id": 38,

--- a/spec/fixtures/api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses/failed-1.json
+++ b/spec/fixtures/api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses/failed-1.json
@@ -1,0 +1,30 @@
+{
+  "url": "https://api.github.com/repos/atmos/slash-heroku/deployments/22233197/statuses/38999643",
+  "id": 38999643,
+  "state": "failed",
+  "creator": {
+    "login": "atmos",
+    "id": 38,
+    "avatar_url": "https://avatars.githubusercontent.com/u/5178170?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/atmos",
+    "html_url": "https://github.com/atmos",
+    "followers_url": "https://api.github.com/users/atmos/followers",
+    "following_url": "https://api.github.com/users/atmos/following{/other_user}",
+    "gists_url": "https://api.github.com/users/atmos/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/atmos/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/atmos/subscriptions",
+    "organizations_url": "https://api.github.com/users/atmos/orgs",
+    "repos_url": "https://api.github.com/users/atmos/repos",
+    "events_url": "https://api.github.com/users/atmos/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/atmos/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "description": "Missing second factor",
+  "target_url": "https://dashboard.heroku.com/apps/slash-heroku-production/activity/builds/da9d8a34-4e6a-4b51-a484-a880ba164995",
+  "created_at": "2017-01-04T19:35:57Z",
+  "updated_at": "2017-01-04T19:35:57Z",
+  "deployment_url": "https://api.github.com/repos/atmos/slash-heroku/deployments/22233197",
+  "repository_url": "https://api.github.com/repos/atmos/slash-heroku"
+}

--- a/spec/lib/escobar/heroku/pipeline_promotion_request_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_promotion_request_spec.rb
@@ -96,6 +96,12 @@ describe Escobar::Heroku::PipelinePromotionRequest do
       .with(headers: default_heroku_headers)
       .to_return(status: 403, body: response, headers: {})
 
+    # Create failed statuses
+    response = fixture_data("api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses/failed-1")
+    stub_request(:post, "https://api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses")
+      .with(headers: default_github_headers)
+      .to_return(status: 200, body: response, headers: {})
+
     expect do
       pipeline.promote(app, targets, "production")
     end.to raise_error(Escobar::Heroku::PipelinePromotion::RequiresTwoFactorError)

--- a/spec/lib/escobar/heroku/pipeline_promotion_request_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_promotion_request_spec.rb
@@ -96,8 +96,8 @@ describe Escobar::Heroku::PipelinePromotionRequest do
       .with(headers: default_heroku_headers)
       .to_return(status: 403, body: response, headers: {})
 
-    # Create failed statuses
-    response = fixture_data("api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses/failed-1")
+    # Create error statuses
+    response = fixture_data("api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses/error-1")
     stub_request(:post, "https://api.github.com/repos/atmos/slash-heroku/deployments/22062424/statuses")
       .with(headers: default_github_headers)
       .to_return(status: 200, body: response, headers: {})


### PR DESCRIPTION
This will close all the promotion GitHub deployments with a failed state when we are missing the 2fa key.

## Why?

We can only know about the second_factor error on POSTing to `/pipeline-promotions`
In builds, we were able to preauth and check before hand.
This is not doable here so this approach will create the github deployment then set it to failed.

## Questions

Should we do similar things for the build?