### PR TITLE
Raise on unauthorized Heroku error

### DIFF
--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -27,6 +27,16 @@ module Escobar
         error.set_backtrace(err.backtrace)
         error
       end
+
+      def self.from_response(resp)
+        error = new("Error from Heroku API")
+
+        error.body    = resp.body
+        error.headers = resp.headers
+        error.status  = resp.status
+
+        error
+      end
     end
 
     def self.from_environment

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -39,6 +39,10 @@ module Escobar
       end
     end
 
+    module Error
+      class Unauthorized < HTTPError; end
+    end
+
     def self.from_environment
       new(Escobar.github_api_token, Escobar.heroku_api_token)
     end

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -17,7 +17,7 @@ module Escobar
     # Class for returning API errors to escobar clients
     class HTTPError < StandardError
       attr_accessor :body, :headers, :status
-      def self.from_response(err)
+      def self.from_error(err)
         error = new("Error from Heroku API")
 
         error.body    = err.response[:body]

--- a/lib/escobar/github/client.rb
+++ b/lib/escobar/github/client.rb
@@ -122,7 +122,7 @@ module Escobar
       rescue Net::OpenTimeout, Faraday::TimeoutError => e
         raise Escobar::Client::TimeoutError.wrap(e)
       rescue Faraday::Error::ClientError => e
-        raise Escobar::Client::HTTPError.from_response(e)
+        raise Escobar::Client::HTTPError.from_error(e)
       end
 
       def client

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -78,7 +78,7 @@ module Escobar
       rescue Net::OpenTimeout, Faraday::TimeoutError => e
         raise Escobar::Client::TimeoutError.wrap(e)
       rescue Faraday::Error::ClientError => e
-        raise Escobar::Client::HTTPError.from_response(e)
+        raise Escobar::Client::HTTPError.from_error(e)
       end
 
       def client

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.4".freeze
+  VERSION = "0.4.5".freeze
 end

--- a/spec/lib/escobar/heroku/client_spec.rb
+++ b/spec/lib/escobar/heroku/client_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Escobar::Heroku::Client do
     end.to raise_error(Escobar::Client::TimeoutError)
   end
 
+  it "should raise on unauthorized error" do
+    stub_request(:get, "https://api.heroku.com/account")
+      .to_return(body: {}.to_json, status: 401)
+    expect do
+      client.get("/account")
+    end.to raise_error(Escobar::Client::Error::Unauthorized)
+  end
+
   it "should correctly handle response from a Faraday ClientError" do
     faraday_error = Faraday::Error::ClientError.new(
       "message",


### PR DESCRIPTION
When Heroku returns a `401` we were not checking `status` code and that means that for pipelines. We can have a `No implicit conversion` for a response that is not expected.

This will raise a `Escobar::Client::Error::Unauthorized` when a `401` is detected.