### PR TITLE
promote 2fa error should mimic deploy error, not an arguement error

### DIFF
--- a/lib/escobar/heroku/pipeline_promotion.rb
+++ b/lib/escobar/heroku/pipeline_promotion.rb
@@ -32,7 +32,8 @@ module Escobar
         end
       end
 
-      class RequiresTwoFactorError < ArgumentError
+      class RequiresTwoFactorError < \
+        Escobar::Heroku::BuildRequest::RequiresTwoFactorError
       end
 
       class MissingContextsError < \
@@ -41,7 +42,7 @@ module Escobar
 
       def raise_2fa_error
         message = "Pipeline requires second factor: #{pipeline.name}"
-        raise RequiresTwoFactorError, message
+        raise RequiresTwoFactorError.new_from_build_request(self, message)
       end
 
       def body

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.5".freeze
+  VERSION = "0.4.6".freeze
 end


### PR DESCRIPTION
It was the only inconsistent error between promoting and deploying. 

There's still a lot of coupling between this error class and slash-heroku itself, which unfortunately digs into the internals of the `build_request_object` to pull out information it wants (e.g. slash heroku calls `error.build_request.pipeline.name` to populate an error back to the user).