### PR TITLE
Unauthorized GitHub should raise

### DIFF
--- a/lib/escobar.rb
+++ b/lib/escobar.rb
@@ -59,6 +59,7 @@ module Escobar
 end
 
 require_relative "./escobar/client"
+require_relative "./escobar/github/response/raise_error"
 require_relative "./escobar/github/client"
 require_relative "./escobar/github/deployment_error"
 require_relative "./escobar/heroku/app"

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -28,8 +28,18 @@ module Escobar
         error
       end
 
-      def self.from_response(resp)
-        error = new("Error from Heroku API")
+      def self.from_response_env(resp, message = "Error from Heroku API")
+        error = new(message)
+
+        error.body    = resp.body
+        error.headers = resp.response_headers
+        error.status  = resp.status
+
+        error
+      end
+
+      def self.from_response(resp, message = "Error from Heroku API")
+        error = new(message)
 
         error.body    = resp.body
         error.headers = resp.headers

--- a/lib/escobar/github/client.rb
+++ b/lib/escobar/github/client.rb
@@ -133,12 +133,16 @@ module Escobar
         Faraday.new(url: "https://api.github.com") do |c|
           c.use :instrumentation
           c.use ZipkinTracer::FaradayHandler, "api.github.com"
+          c.use Escobar::GitHub::Response::RaiseError
           c.adapter Faraday.default_adapter
         end
       end
 
       def default_client
-        Faraday.new(url: "https://api.github.com")
+        Faraday.new(url: "https://api.github.com") do |c|
+          c.use Escobar::GitHub::Response::RaiseError
+          c.adapter Faraday.default_adapter
+        end
       end
     end
   end

--- a/lib/escobar/github/response/raise_error.rb
+++ b/lib/escobar/github/response/raise_error.rb
@@ -1,0 +1,19 @@
+module Escobar
+  module GitHub
+    module Response
+      # Faraday response middleware to handle API errors
+      # This will translate status to Escobar::Client::Errors
+      class RaiseError < ::Faraday::Response::Middleware
+        private
+
+        def on_complete(response)
+          case response.status
+          when 401
+            raise Escobar::Client::Error::Unauthorized
+              .from_response_env(response, "GitHub Unauthorized")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/escobar/github/client_spec.rb
+++ b/spec/lib/escobar/github/client_spec.rb
@@ -57,6 +57,16 @@ describe Escobar::GitHub::Client do
         slash_heroku.default_branch
       end.to raise_error(Escobar::GitHub::RepoNotFound)
     end
+
+    it "raises a Unauthorized error if we get a 401" do
+      stub_request(:get, "https://api.github.com/repos/atmos/slash-heroku")
+        .with(headers: default_github_headers)
+        .to_return(status: 401, body: {}.to_json, headers: {})
+
+      expect do
+        slash_heroku.default_branch
+      end.to raise_error(Escobar::Client::Error::Unauthorized)
+    end
   end
 
   describe "#required_contexts" do


### PR DESCRIPTION
This PR introduce a `raise_error` middleware for Faraday GitHub client.
It will raise on 401 a new `Escobar::Client::Error::Unauthorized`.
Maybe we want to specialize errors per provider: `GitHub` or `Heroku` to differentiate them higher in the stack.

## Why?

We raise `RepoNotFound` when the token has been revoked and return not accurate responses to users.

## Another solution?

Use `Octokit` instead of this custom code.
That would allow us to reuse Octokit Client at places that do not fit the Escobar way:)