### PR TITLE
Repos are case sensitive

### DIFF
--- a/lib/escobar/github/client.rb
+++ b/lib/escobar/github/client.rb
@@ -1,5 +1,7 @@
 module Escobar
   module GitHub
+    REPOSITORY_REGEX = %r{https:\/\/api\.github\.com\/repos\/([-_\.0-9a-zA-Z]+\/[-_\.0-9a-zA-Z]+)} # rubocop:disable LineLength
+
     class RepoNotFound < StandardError; end
     # Top-level class for interacting with GitHub API
     class Client

--- a/lib/escobar/heroku/build.rb
+++ b/lib/escobar/heroku/build.rb
@@ -39,12 +39,8 @@ module Escobar
         "https://dashboard.heroku.com/apps/#{app.name}/activity/builds/#{id}"
       end
 
-      def repository_regex
-        %r{https:\/\/api\.github\.com\/repos\/([-_\.0-9a-z]+\/[-_\.0-9a-z]+)}
-      end
-
       def repository
-        github_url && github_url.match(repository_regex)[1]
+        github_url && github_url.match(Escobar::GitHub::REPOSITORY_REGEX)[1]
       end
 
       def to_job_json

--- a/lib/escobar/heroku/release.rb
+++ b/lib/escobar/heroku/release.rb
@@ -41,11 +41,7 @@ module Escobar
       end
 
       def repository
-        github_url && github_url.match(repository_regex)[1]
-      end
-
-      def repository_regex
-        %r{https:\/\/api\.github\.com\/repos\/([-_\.0-9a-z]+\/[-_\.0-9a-z]+)}
+        github_url && github_url.match(Escobar::GitHub::REPOSITORY_REGEX)[1]
       end
 
       def status

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.9".freeze
+  VERSION = "0.4.10".freeze
 end

--- a/spec/lib/escobar/heroku/build_spec.rb
+++ b/spec/lib/escobar/heroku/build_spec.rb
@@ -41,4 +41,13 @@ describe Escobar::Heroku::Build do
         "builds/b80207dc-139f-4546-aedc-985d9cfcafab"
       )
   end
+
+  it "handles mixed case github url" do
+    build = Escobar::Heroku::Build.new(
+      client, app.id, "b80207dc-139f-4546-aedc-985d9cfcafab"
+    )
+
+    build.github_url = "https://api.github.com/repos/HEROKU/Slash-Heroku/deployments/9876543210" # rubocop:disable LineLength
+    expect(build.repository).to eql("HEROKU/Slash-Heroku")
+  end
 end

--- a/spec/lib/escobar/heroku/release_spec.rb
+++ b/spec/lib/escobar/heroku/release_spec.rb
@@ -58,4 +58,15 @@ describe Escobar::Heroku::Release do
 
     expect(release.ref).to eql("f7c319ed2be5d9de5d6bc71665101d6f49836439")
   end
+
+  it "handles mixed case github url" do
+    release = Escobar::Heroku::Release.new(
+      client,
+      app.id,
+      "b80207dc-139f-4546-aedc-985d9cfcafab",
+      "23fe935d-88c8-4fd0-b035-10d44f3d9059"
+    )
+    release.github_url = "https://api.github.com/repos/HEROKU/Slash-Heroku/releases/23fe935d-88c8-4fd0-b035-10d44f3d9059" # rubocop:disable LineLength
+    expect(release.repository).to eql("HEROKU/Slash-Heroku")
+  end
 end


### PR DESCRIPTION
Some folks have upper case in their organization or repository name.

This fixes issues where the regex is not matching.