### PR TITLE
Rescue ConnectionFailed correctly

### DIFF
--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -73,7 +73,8 @@ module Escobar
         resp = yield
         raise_on_status(resp)
         resp
-      rescue Net::OpenTimeout, Faraday::TimeoutError => e
+      rescue Net::OpenTimeout, Faraday::TimeoutError,
+             Faraday::Error::ConnectionFailed => e
         raise Escobar::Client::TimeoutError.wrap(e)
       rescue Faraday::Error::ClientError => e
         raise Escobar::Client::HTTPError.from_error(e)

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.10".freeze
+  VERSION = "0.4.11".freeze
 end

--- a/spec/lib/escobar/heroku/client_spec.rb
+++ b/spec/lib/escobar/heroku/client_spec.rb
@@ -9,6 +9,14 @@ RSpec.describe Escobar::Heroku::Client do
     end.to raise_error(Escobar::Client::TimeoutError)
   end
 
+  it "should rescue timeout errors" do
+    stub_request(:get, "https://api.heroku.com/account")
+      .to_raise(Net::OpenTimeout)
+    expect do
+      client.get("/account")
+    end.to raise_error(Escobar::Client::TimeoutError)
+  end
+
   it "should raise on unauthorized error" do
     stub_request(:get, "https://api.heroku.com/account")
       .to_return(body: {}.to_json, status: 401)


### PR DESCRIPTION
Faraday is wrapping `Net::OpenTimeout` in a `Faraday::Error::ConnectionFailed` which is inheriting from `Faraday::Error::ClientError`.
That means that the Faraday error goes to the wrong rescue in `Heroku::Client`
This fixes that behavior and consider all `ConnectionFailed` to be some timeouts for now.

If we want finer control it is ok to change this later.

For now it fixes a bug where the `OpenTimeout` is considered as a normal `HTTPError` and we try to extract `body` and `status`