### PR TITLE
Raise a different kind of exception when getting 2fa errors

### DIFF
--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -51,6 +51,7 @@ module Escobar
 
     module Error
       class Unauthorized < HTTPError; end
+      class TwoFactorMissing < HTTPError; end
     end
 
     def self.from_environment

--- a/lib/escobar/client.rb
+++ b/lib/escobar/client.rb
@@ -51,7 +51,7 @@ module Escobar
 
     module Error
       class Unauthorized < HTTPError; end
-      class TwoFactorMissing < HTTPError; end
+      class SecondFactor < HTTPError; end
     end
 
     def self.from_environment

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -84,8 +84,8 @@ module Escobar
         case resp.status
         when 401
           body = JSON.parse(resp.body)
-          raise Escobar::Client::Error::TwoFactorMissing.from_response(resp) \
-            if body["message"]&.match(/factor/)
+          raise Escobar::Client::Error::SecondFactor.from_response(resp) \
+            if body["id"] == "two_factor"
           raise Escobar::Client::Error::Unauthorized.from_response(resp)
         end
       end

--- a/lib/escobar/heroku/client.rb
+++ b/lib/escobar/heroku/client.rb
@@ -60,7 +60,7 @@ module Escobar
             request.url path
             request_defaults(request)
             if second_factor
-              request.headers["Heroku-Two-Factor-Code"] = second_factor
+              request.headers["Heroku-Two-Factor-Code"] = second_factor.to_s
             end
           end
         end
@@ -83,6 +83,9 @@ module Escobar
       def raise_on_status(resp)
         case resp.status
         when 401
+          body = JSON.parse(resp.body)
+          raise Escobar::Client::Error::TwoFactorMissing.from_response(resp) \
+            if body["message"]&.match(/factor/)
           raise Escobar::Client::Error::Unauthorized.from_response(resp)
         end
       end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.12.pre1".freeze
+  VERSION = "0.4.12".freeze
 end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.11".freeze
+  VERSION = "0.4.12.pre1".freeze
 end

--- a/spec/lib/escobar/heroku/client_spec.rb
+++ b/spec/lib/escobar/heroku/client_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Escobar::Heroku::Client do
     end.to raise_error(Escobar::Client::Error::Unauthorized)
   end
 
+  it "should raise on invalid two factor error" do
+    stub_request(:get, "https://api.heroku.com/account")
+      .to_return(body: { id: "two_factor" }.to_json, status: 401)
+    expect do
+      client.get("/account")
+    end.to raise_error(Escobar::Client::Error::SecondFactor)
+  end
+
   it "should correctly handle response from a Faraday ClientError" do
     faraday_error = Faraday::Error::ClientError.new(
       "message",


### PR DESCRIPTION
It's difficult to differentiate between a user needing to reauthenticate and a user getting rejected for actions requiring a second factor. This treats those errors differently.