### PR TITLE
Update zipkin-tracer

### DIFF
--- a/escobar.gemspec
+++ b/escobar.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", "~> 0.9.2"
   spec.add_dependency "netrc", "~> 0.11"
-  spec.add_dependency "zipkin-tracer", "~> 0.18"
+  spec.add_dependency "zipkin-tracer", "~> 0.24"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "byebug"

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.13".freeze
+  VERSION = "0.4.14".freeze
 end


### PR DESCRIPTION
Last version is `0.24`