### PR TITLE
Ensure the Header is there on 2fa

### DIFF
--- a/lib/escobar/heroku/app.rb
+++ b/lib/escobar/heroku/app.rb
@@ -54,7 +54,7 @@ module Escobar
 
       # Accepts either google authenticator or yubikey second_factor formatting
       def preauth(second_factor)
-        heroku.put("/apps/#{id}/pre-authorizations", "", second_factor).none?
+        heroku.put("/apps/#{id}/pre-authorizations", {}, second_factor).none?
       end
 
       def locked?

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.16".freeze
+  VERSION = "0.4.17".freeze
 end

--- a/spec/lib/escobar/heroku/app_spec.rb
+++ b/spec/lib/escobar/heroku/app_spec.rb
@@ -21,8 +21,9 @@ describe Escobar::Heroku::App do
     expect(app.name).to eql("slash-heroku-production")
 
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/pre-authorizations"
+    headers = default_heroku_headers.merge("Heroku-Two-Factor-Code": "867530")
     stub_request(:put, "https://api.heroku.com#{path}")
-      .with(headers: default_heroku_headers)
+      .with(headers: headers)
       .to_return(
         status: 200, body: fixture_data("api.heroku.com#{path}")
       )
@@ -33,8 +34,9 @@ describe Escobar::Heroku::App do
     expect(app.name).to eql("slash-heroku-production")
 
     path = "/apps/b0deddbf-cf56-48e4-8c3a-3ea143be2333/pre-authorizations"
+    headers = default_heroku_headers.merge("Heroku-Two-Factor-Code": "867530")
     stub_request(:put, "https://api.heroku.com#{path}")
-      .with(headers: default_heroku_headers)
+      .with(headers: headers)
       .to_return(
         status: 200, body: fixture_data("api.heroku.com#{path}-failed")
       )


### PR DESCRIPTION
Adding a condition to the specs to be sure we have the right header for 2fa.

Also fixing the error where we try to json encode `""` and it ends up being a non valid json string...