### PR TITLE
Expose the github_repository_id for a pipeline

### DIFF
--- a/lib/escobar/heroku/pipeline.rb
+++ b/lib/escobar/heroku/pipeline.rb
@@ -46,6 +46,11 @@ module Escobar
           remote_repository["repository"]["name"]
       end
 
+      def github_repository_id
+        remote_repository["repository"] &&
+          remote_repository["repository"]["id"]
+      end
+
       def couplings
         @couplings ||= remote_couplings_without_test_stage
       end

--- a/lib/escobar/version.rb
+++ b/lib/escobar/version.rb
@@ -1,3 +1,3 @@
 module Escobar
-  VERSION = "0.4.18".freeze
+  VERSION = "0.4.19".freeze
 end

--- a/spec/lib/escobar/heroku/pipeline_spec.rb
+++ b/spec/lib/escobar/heroku/pipeline_spec.rb
@@ -24,6 +24,7 @@ describe Escobar::Heroku::Pipeline do
 
       pipeline = Escobar::Heroku::Pipeline.new(client, id, name)
       expect(pipeline.github_repository).to eql("atmos/slash-heroku")
+      expect(pipeline.github_repository_id).to eql(53_173_861)
       expect(pipeline).to be_configured
       expect(pipeline.heroku_permalink)
         .to eql("https://dashboard.heroku.com/pipelines/#{id}")


### PR DESCRIPTION
We already expose the repository name.
Since it might change, exposing the repository ID allows to later
reference it even if it was changed.